### PR TITLE
Add support for subaddresses

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,5 +1,5 @@
 'use strict';
-const re = '4[0-9AB][1-9A-HJ-NP-Za-km-z]{93}';
+const re = '[48][0-9AB][1-9A-HJ-NP-Za-km-z]{93}';
 
 module.exports = options => {
 	options = options || {};


### PR DESCRIPTION
Subaddresses - addresses starting with an '8' - are valid and functionally equivalent Monero addresses.